### PR TITLE
fixes a bug where leading zeros were truncated

### DIFF
--- a/lib/aws_auth.ex
+++ b/lib/aws_auth.ex
@@ -16,18 +16,18 @@ defmodule AWSAuth do
 
   `service`: The AWS service you are trying to access (i.e. s3). Check the url above for names as well.
 
-  `headers` (optional. defaults to `HashDict.new`): The headers that will be used in the request. Used for signing the request. 
-  For signing, host is the only one required unless using any other x-amx-* headers. 
-  If host is present here, it will override using the host in the url to attempt signing. 
-  If only the host is needed, then you don't have to supply it and the host from the url will be used. 
-   """ 
+  `headers` (optional. defaults to `HashDict.new`): The headers that will be used in the request. Used for signing the request.
+  For signing, host is the only one required unless using any other x-amx-* headers.
+  If host is present here, it will override using the host in the url to attempt signing.
+  If only the host is needed, then you don't have to supply it and the host from the url will be used.
+   """
   def sign_url(access_key, secret_key, http_method, url, region, service) do
     sign_url(access_key, secret_key, http_method, url, region, service, HashDict.new)
-  end  
+  end
 
   def sign_url(access_key, secret_key, http_method, url, region, service, headers) do
     sign_url(access_key, secret_key, http_method, url, region, service, headers, Date.now)
-  end 
+  end
 
   def sign_url(access_key, secret_key, http_method, url, region, service, headers, request_time) do
     AWSAuth.QueryParameters.sign(access_key, secret_key, http_method, url, region, service, headers, request_time)
@@ -49,22 +49,22 @@ defmodule AWSAuth do
 
   `service`: The AWS service you are trying to access (i.e. s3). Check the url above for names as well.
 
-  `headers` (optional. defaults to `HashDict.new`): The headers that will be used in the request. Used for signing the request. 
-  For signing, host is the only one required unless using any other x-amx-* headers. 
+  `headers` (optional. defaults to `HashDict.new`): The headers that will be used in the request. Used for signing the request.
+  For signing, host is the only one required unless using any other x-amx-* headers.
   If host is present here, it will override using the host in the url to attempt signing.
-  Same goes for the x-amz-content-sha256 headers 
-  If only the host and x-amz-content-sha256 headers are needed, then you don't have to supply it and the host from the url will be used and 
+  Same goes for the x-amz-content-sha256 headers
+  If only the host and x-amz-content-sha256 headers are needed, then you don't have to supply it and the host from the url will be used and
   the payload will be hashed to get the x-amz-content-sha256 header.
 
-  `payload` (optional. defaults to `""`): The contents of the payload if there is one. 
+  `payload` (optional. defaults to `""`): The contents of the payload if there is one.
   """
   def sign_authorization_header(access_key, secret_key, http_method, url, region, service) do
     sign_authorization_header(access_key, secret_key, http_method, url, region, service, HashDict.new)
-  end  
+  end
 
   def sign_authorization_header(access_key, secret_key, http_method, url, region, service, headers) do
     sign_authorization_header(access_key, secret_key, http_method, url, region, service, headers, "")
-  end 
+  end
 
   def sign_authorization_header(access_key, secret_key, http_method, url, region, service, headers, payload) do
     sign_authorization_header(access_key, secret_key, http_method, url, region, service, headers, payload, Date.now)

--- a/lib/aws_auth/authorization_header.ex
+++ b/lib/aws_auth/authorization_header.ex
@@ -20,7 +20,7 @@ defmodule AWSAuth.AuthorizationHeader do
                 {hd(x), List.last(x)}
             end
 
-            Dict.put(acc, key,  AWSAuth.Utils.uri_encode(value)) 
+            Dict.put(acc, key,  AWSAuth.Utils.uri_encode(value))
         end)
     end
 
@@ -46,11 +46,11 @@ defmodule AWSAuth.AuthorizationHeader do
     string_to_sign =  AWSAuth.Utils.build_canonical_request(http_method, uri.path || "/", params, headers, hashed_payload)
     |>  AWSAuth.Utils.build_string_to_sign(amz_date, scope)
 
-    signature =  AWSAuth.Utils.build_signing_key(secret_key, date, region, service) 
+    signature =  AWSAuth.Utils.build_signing_key(secret_key, date, region, service)
     |>  AWSAuth.Utils.build_signature(string_to_sign)
 
-    signed_headers = Enum.map(headers, fn({key, _}) -> String.downcase(key)  end) 
-    |> Enum.sort(&(&1 < &2)) 
+    signed_headers = Enum.map(headers, fn({key, _}) -> String.downcase(key)  end)
+    |> Enum.sort(&(&1 < &2))
     |> Enum.join(";")
 
     "AWS4-HMAC-SHA256 Credential=#{access_key}/#{scope},SignedHeaders=#{signed_headers},Signature=#{signature}"

--- a/lib/aws_auth/query_parameters.ex
+++ b/lib/aws_auth/query_parameters.ex
@@ -38,7 +38,7 @@ defmodule AWSAuth.QueryParameters do
     string_to_sign = AWSAuth.Utils.build_canonical_request(http_method, uri.path, params, headers, :unsigned)
     |> AWSAuth.Utils.build_string_to_sign(amz_date, scope)
 
-    signature = AWSAuth.Utils.build_signing_key(secret_key, date, region, service) 
+    signature = AWSAuth.Utils.build_signing_key(secret_key, date, region, service)
     |> AWSAuth.Utils.build_signature(string_to_sign)
 
     params = Dict.put(params, "X-Amz-Signature", signature)

--- a/lib/aws_auth/utils.ex
+++ b/lib/aws_auth/utils.ex
@@ -2,18 +2,16 @@ defmodule AWSAuth.Utils do
 
   def build_canonical_request(http_method, url, params, headers, hashed_payload) do
 
-    query_params = Enum.map(params, fn({key, value}) -> "#{key}=#{value}"  end) 
-    |> Enum.sort(&(&1 < &2))  
+    query_params = Enum.map(params, fn({key, value}) -> "#{key}=#{value}"  end)
+    |> Enum.sort(&(&1 < &2))
     |> Enum.join("&")
 
-
-    header_params = Enum.map(headers, fn({key, value}) -> "#{String.downcase(key)}:#{String.strip(value)}"  end) 
-    |> Enum.sort(&(&1 < &2)) 
+    header_params = Enum.map(headers, fn({key, value}) -> "#{String.downcase(key)}:#{String.strip(value)}"  end)
+    |> Enum.sort(&(&1 < &2))
     |> Enum.join("\n")
 
-
-    signed_header_params = Enum.map(headers, fn({key, _}) -> String.downcase(key)  end) 
-    |> Enum.sort(&(&1 < &2)) 
+    signed_header_params = Enum.map(headers, fn({key, _}) -> String.downcase(key)  end)
+    |> Enum.sort(&(&1 < &2))
     |> Enum.join(";")
 
     if hashed_payload == :unsigned do
@@ -23,9 +21,9 @@ defmodule AWSAuth.Utils do
     "#{http_method}\n#{URI.encode(url) |> String.replace("$", "%24")}\n#{query_params}\n#{header_params}\n\n#{signed_header_params}\n#{hashed_payload}"
   end
 
-  def build_string_to_sign(canonical_request, timestamp, scope) do    
+  def build_string_to_sign(canonical_request, timestamp, scope) do
     hashed_canonical_request = hash_sha256(canonical_request)
-    
+
     "AWS4-HMAC-SHA256\n#{timestamp}\n#{scope}\n#{hashed_canonical_request}"
   end
 
@@ -42,7 +40,7 @@ defmodule AWSAuth.Utils do
   end
 
   def hash_sha256(data) do
-    :crypto.hash(:sha256, data) 
+    :crypto.hash(:sha256, data)
     |> bytes_to_string
   end
 
@@ -60,8 +58,8 @@ defmodule AWSAuth.Utils do
   end
 
   def bytes_to_string(bytes) do
-    :crypto.bytes_to_integer(bytes)
-    |> Integer.to_string(16)
+    bytes
+    |> Base.encode16
     |> String.downcase
   end
 

--- a/test/aws_auth_test.exs
+++ b/test/aws_auth_test.exs
@@ -3,9 +3,9 @@ defmodule AWSAuthTest do
 
   test "url signing" do
     signed_request = AWSAuth.sign_url("AKIAIOSFODNN7EXAMPLE", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-      "GET", 
-      "https://examplebucket.s3.amazonaws.com/test.txt", 
-      "us-east-1", 
+      "GET",
+      "https://examplebucket.s3.amazonaws.com/test.txt",
+      "us-east-1",
       "s3",
       HashDict.new,
       Timex.Date.from({2013,05,24}, Timex.Date.timezone("GMT")))
@@ -19,9 +19,9 @@ defmodule AWSAuthTest do
     |> Dict.put("x-amz-date", "20130524T000000Z")
 
     signed_request = AWSAuth.sign_authorization_header("AKIAIOSFODNN7EXAMPLE", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-      "GET", 
-      "https://examplebucket.s3.amazonaws.com/test.txt", 
-      "us-east-1", 
+      "GET",
+      "https://examplebucket.s3.amazonaws.com/test.txt",
+      "us-east-1",
       "s3",
       headers,
       "",
@@ -37,9 +37,9 @@ defmodule AWSAuthTest do
     |> Dict.put("x-amz-date", "20130524T000000Z")
 
     signed_request = AWSAuth.sign_authorization_header("AKIAIOSFODNN7EXAMPLE", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-      "PUT", 
-      "https://examplebucket.s3.amazonaws.com/test$file.text", 
-      "us-east-1", 
+      "PUT",
+      "https://examplebucket.s3.amazonaws.com/test$file.text",
+      "us-east-1",
       "s3",
       headers,
       "Welcome to Amazon S3.",
@@ -51,11 +51,11 @@ defmodule AWSAuthTest do
   test "sign_query_parameters_request_with_multiple_headers" do
     headers = HashDict.new
     |> Dict.put("x-amz-acl", "public-read")
-    
+
     signed_request = AWSAuth.sign_url("AKIAIOSFODNN7EXAMPLE", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-      "PUT", 
-      "https://examplebucket.s3.amazonaws.com/test.txt", 
-      "us-east-1", 
+      "PUT",
+      "https://examplebucket.s3.amazonaws.com/test.txt",
+      "us-east-1",
       "s3",
       headers,
       Timex.Date.from({2013,05,24}, Timex.Date.timezone("GMT")))


### PR DESCRIPTION
The following payload when you hash it generates a binary that, when going through the bytes_to_string function generates the wrong result, likely due to the leading zero.

```
POST
/

content-type:application/x-amz-json-1.1
host:kinesis.us-east-1.amazonaws.com
x-amz-date:20150407T031300Z
x-amz-target:Kinesis_20131202.GetRecords

content-type;host;x-amz-date;x-amz-target
c51920cde0a6d4ef0e5c3d0adb3a1096c68710c6e510d5b502c10d724496699c
```

It should be: 

`````` 0b354764965128d7400fa810257cf433dffaa27084013768035504fced816c2d```
Instead its
```b354764965128d7400fa810257cf433dffaa27084013768035504fced816c2d```

At the same time there were a bunch of trailing spaces in the code that my text editor cleaned up
``````
